### PR TITLE
fix: Quote remote rsync paths to handle spaces correctly

### DIFF
--- a/sync/lib/sync-lib.sh
+++ b/sync/lib/sync-lib.sh
@@ -96,7 +96,7 @@ init_sync() {
     if [[ "$ENABLE_NAS_BACKUP" == "true" ]]; then
         NAS="${NAS_BASE}/${NAS_SUBDIR}"
     fi
-    PLEX="${PLEX_SERVER}:${PLEX_BASE}/${PLEX_SUBDIR}"
+    PLEX="${PLEX_SERVER}:'${PLEX_BASE}/${PLEX_SUBDIR}'"
     
     # Exclude file path
     EXCLUDE_FILE_PATH="${SYNC_DIR}/${EXCLUDE_FILE}"

--- a/tests/music-sync.bats
+++ b/tests/music-sync.bats
@@ -75,7 +75,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"Artist: Test Artist"* ]]
     [[ "$output" == *"Source: ${TEST_TMP_DIR}/source/Test Artist/"* ]]
-    [[ "$output" == *"Plex Target: test-server:/test/plex/Test Artist/Live/"* ]]
+    [[ "$output" == *"Plex Target: test-server:'/test/plex/Test Artist/Live/'"* ]]
     assert_rsync_called_with "${TEST_TMP_DIR}/source/Test Artist/"
 }
 
@@ -131,7 +131,7 @@ EOF
     # Check that both NAS and Plex syncs occurred
     assert_rsync_called_with "${TEST_TMP_DIR}/source/Full Test/"
     assert_rsync_called_with "${TEST_TMP_DIR}/nas/Full Test/"
-    assert_rsync_called_with "test-server:/test/plex/Full Test/Live/"
+    assert_rsync_called_with "test-server:'/test/plex/Full Test/Live/'"
     
     # Check verification ran
     [[ "$output" == *"Full test verification"* ]]

--- a/tests/sync-lib.bats
+++ b/tests/sync-lib.bats
@@ -84,7 +84,7 @@ teardown() {
     run bash -c "source '${TEST_TMP_DIR}/sync-lib-test.sh' && parse_args test-artist && init_sync && echo SRC=\$SRC && echo PLEX=\$PLEX && echo EXCLUDE_FILE_PATH=\$EXCLUDE_FILE_PATH"
     [ "$status" -eq 0 ]
     [[ "$output" == *"SRC=${TEST_TMP_DIR}/source/Test Artist/"* ]]
-    [[ "$output" == *"PLEX=test-server:/test/plex/Test Artist/Live/"* ]]
+    [[ "$output" == *"PLEX=test-server:'/test/plex/Test Artist/Live/'"* ]]
     [[ "$output" == *"EXCLUDE_FILE_PATH=${TEST_TMP_DIR}/test-excludes.txt"* ]]
 }
 
@@ -151,7 +151,7 @@ EOF
     assert_rsync_called_with "--delete-excluded"
     assert_rsync_called_with "--exclude-from=${TEST_TMP_DIR}/test-excludes.txt"
     assert_rsync_called_with "${TEST_TMP_DIR}/source/Test Artist/"
-    assert_rsync_called_with "test-server:/test/plex/Test Artist/Live/"
+    assert_rsync_called_with "test-server:'/test/plex/Test Artist/Live/'"
 }
 
 @test "run_verification skips in dry run mode" {


### PR DESCRIPTION
Previously, rsync destinations with spaces in paths (like "Dead and Company") would be truncated at the first space, causing syncs to fail or go to wrong locations. This fix properly quotes the remote path portion after the colon.

🤖 Generated with [Claude Code](https://claude.ai/code)