### PR TITLE
fix: No non-live Dead and Company

### DIFF
--- a/sync/config/dead-and-company.conf
+++ b/sync/config/dead-and-company.conf
@@ -11,7 +11,7 @@ SOURCE_SUBDIR="Dead and Company/"
 ENABLE_NAS_BACKUP=false
 
 # Plex sync settings  
-PLEX_SUBDIR="Dead and Company/Live/"
+PLEX_SUBDIR="Dead and Company/"
 
 # Exclude file for filtering studio albums
 EXCLUDE_FILE="dead-and-company-excludes.txt"


### PR DESCRIPTION
They are only a live band and do not have studio albums. No need for a Live sub-folder on Plex..