### PR TITLE
Do not mix live and not-live music

### DIFF
--- a/sync/config/global.conf
+++ b/sync/config/global.conf
@@ -9,7 +9,7 @@ NAS_BASE="/Volumes/ian/blackhole"
 
 # Plex server configuration
 PLEX_SERVER="tranquility"
-PLEX_BASE="/data/media/Sorted/Music"
+PLEX_BASE="/data/media/Sorted/Unsorted/Music"
 
 # Rsync configuration
 PARTIAL_DIR="/Volumes/Fatboy/Music/iTunes/Music/.rsync-partial"


### PR DESCRIPTION
It was a bad idea for the way I'm managing things. Keep them separate. Yes, I know `Unsorted` is a terrible directory name. Especially underneath `Sorted`. Is what it is.