### PR TITLE
feat: add phish-merge CLI for merging live show collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
 # Audio files
 *.flac
 *.m4a

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+phish-merge — Merge an existing Phish live show collection with a torrent download.
+
+Runs five phases in order: pre-flight, NAS backup, copy new shows, replace matched
+shows with canonical torrent copies, rename existing-only shows to torrent naming.
+
+Usage:
+  phish-merge [--dry-run]
+  phish-merge --execute --nas PATH
+  phish-merge --existing PATH --torrent PATH --execute --nas PATH
+
+Options:
+  --existing PATH   Existing live collection path
+  --torrent  PATH   Torrent directory path
+  --nas      PATH   NAS backup destination (required with --execute)
+  --dry-run         Print planned actions, touch nothing [default]
+  --execute         Perform the actual merge
+  -h, --help        Show this message
+"""
+
+import os
+import re
+import sys
+import shutil
+import subprocess
+from pathlib import Path
+from collections import defaultdict
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+
+DEFAULT_EXISTING = Path("/data/media/Sorted/Unsorted/Music/Phish")
+DEFAULT_TORRENT  = Path("/data/torrents/Phish-Live.Phish.Project-2002-2026")
+
+# ── Terminal ──────────────────────────────────────────────────────────────────
+
+try:
+    COLS = min(os.get_terminal_size().columns, 160)
+except OSError:
+    COLS = 120
+
+USE_COLOR = sys.stdout.isatty()
+
+def _ansi(code, s):
+    return f"\033[{code}m{s}\033[0m" if USE_COLOR else s
+
+def bold(s):   return _ansi("1",  s)
+def dim(s):    return _ansi("2",  s)
+def red(s):    return _ansi("91", s)
+def green(s):  return _ansi("92", s)
+def yellow(s): return _ansi("93", s)
+
+
+def parse_args(argv):
+    existing_path = DEFAULT_EXISTING
+    torrent_path  = DEFAULT_TORRENT
+    nas_path      = None
+    dry_run       = True
+
+    args = argv[1:]
+    i = 0
+    while i < len(args):
+        if args[i] in ("-e", "--existing") and i + 1 < len(args):
+            existing_path = Path(args[i + 1]); i += 2
+        elif args[i] in ("-t", "--torrent") and i + 1 < len(args):
+            torrent_path = Path(args[i + 1]); i += 2
+        elif args[i] in ("-n", "--nas") and i + 1 < len(args):
+            nas_path = Path(args[i + 1]); i += 2
+        elif args[i] == "--dry-run":
+            dry_run = True; i += 1
+        elif args[i] == "--execute":
+            dry_run = False; i += 1
+        elif args[i] in ("-h", "--help"):
+            print(__doc__)
+            sys.exit(0)
+        else:
+            print(f"Unknown argument: {args[i]}", file=sys.stderr)
+            sys.exit(1)
+
+    return existing_path, torrent_path, nas_path, dry_run
+
+
+def main():
+    existing_path, torrent_path, nas_path, dry_run = parse_args(sys.argv)
+    mode = "DRY RUN" if dry_run else "EXECUTE"
+    print(f"\n  {bold('PHISH MERGE')}  [{mode}]")
+    print(f"  {dim('Existing:')}  {existing_path}")
+    print(f"  {dim('Torrent: ')}  {torrent_path}")
+    if not dry_run:
+        print(f"  {dim('NAS:     ')}  {nas_path}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -207,6 +207,44 @@ def phase_rename_existing(existing_path: Path, ex_only_dates: list,
     return count
 
 
+def phase_summary(new_count: int, replaced_count: int, renamed_count: int,
+                  existing_path: Path, dry_run: bool):
+    mode = "DRY RUN — would have" if dry_run else "Complete."
+    print(f"\n  {bold('SUMMARY')}  [{mode}]")
+    print(f"  {green(str(new_count))}  shows copied from torrent (new)")
+    print(f"  {green(str(replaced_count))}  shows replaced with torrent canonical copy")
+    print(f"  {yellow(str(renamed_count))}  existing-only shows renamed to torrent style")
+    if not dry_run:
+        print()
+        print(f"  {bold('Next step:')} trigger a Plex library scan for:")
+        print(f"    {existing_path}")
+        print()
+        print(f"  {bold('Important:')} do not run `music-sync phish` again.")
+        print(f"  tranquility is now the source of truth for the Phish collection.")
+    print()
+
+
+def main_logic(existing_path: Path, torrent_path: Path, nas_path, dry_run: bool):
+    ex_dated, _ex_undated = load(existing_path, date_from_existing)
+    tr_dated, _tr_undated = load(torrent_path,  date_from_torrent)
+
+    ex_dates      = set(ex_dated.keys())
+    tr_dates      = set(tr_dated.keys())
+    matched_dates = sorted(ex_dates & tr_dates)
+    ex_only_dates = sorted(ex_dates - tr_dates)
+    tr_only_dates = sorted(tr_dates - ex_dates)
+
+    print(f"  {len(ex_dates)} existing  ·  {len(tr_dates)} torrent  ·  "
+          f"{len(matched_dates)} matched  ·  {len(ex_only_dates)} existing-only  ·  "
+          f"{len(tr_only_dates)} torrent-only\n")
+
+    phase_backup(existing_path, nas_path, dry_run)
+    new_count      = phase_copy_new(torrent_path, existing_path, tr_only_dates, tr_dated, dry_run)
+    replaced_count = phase_replace_matched(torrent_path, existing_path, matched_dates, ex_dated, tr_dated, dry_run)
+    renamed_count  = phase_rename_existing(existing_path, ex_only_dates, ex_dated, dry_run)
+    phase_summary(new_count, replaced_count, renamed_count, existing_path, dry_run)
+
+
 def parse_args(argv):
     existing_path = DEFAULT_EXISTING
     torrent_path  = DEFAULT_TORRENT
@@ -252,6 +290,7 @@ def main():
         print(f"  {dim('NAS:     ')}  {nas_path}")
     print()
     preflight(existing_path, torrent_path, nas_path, not dry_run)
+    main_logic(existing_path, torrent_path, nas_path, dry_run)
 
 
 if __name__ == "__main__":

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -100,6 +100,23 @@ def existing_to_torrent_name(dirname: str, date: str) -> str:
     return f"Phish-{date}.{name}"
 
 
+def preflight(existing_path: Path, torrent_path: Path, nas_path, execute: bool):
+    errors = []
+    if not existing_path.exists():
+        errors.append(f"Existing path does not exist: {existing_path}")
+    if not torrent_path.exists():
+        errors.append(f"Torrent path does not exist: {torrent_path}")
+    if execute:
+        if nas_path is None:
+            errors.append("--nas PATH is required with --execute")
+        elif not Path(nas_path).exists():
+            errors.append(f"NAS path does not exist: {nas_path}")
+    if errors:
+        for e in errors:
+            print(f"  {red('Error:')} {e}", file=sys.stderr)
+        sys.exit(1)
+
+
 def parse_args(argv):
     existing_path = DEFAULT_EXISTING
     torrent_path  = DEFAULT_TORRENT
@@ -144,6 +161,7 @@ def main():
     if not dry_run:
         print(f"  {dim('NAS:     ')}  {nas_path}")
     print()
+    preflight(existing_path, torrent_path, nas_path, not dry_run)
 
 
 if __name__ == "__main__":

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -11,12 +11,12 @@ Usage:
   phish-merge --existing PATH --torrent PATH --execute --nas PATH
 
 Options:
-  --existing PATH   Existing live collection path
-  --torrent  PATH   Torrent directory path
-  --nas      PATH   NAS backup destination (required with --execute)
-  --dry-run         Print planned actions, touch nothing [default]
-  --execute         Perform the actual merge
-  -h, --help        Show this message
+  -e, --existing PATH   Existing live collection path
+  -t, --torrent  PATH   Torrent directory path
+      --nas      PATH   NAS backup destination (required with --execute)
+      --dry-run         Print planned actions, touch nothing [default]
+      --execute         Perform the actual merge
+  -h, --help            Show this message
 """
 
 import os
@@ -60,11 +60,17 @@ def parse_args(argv):
     args = argv[1:]
     i = 0
     while i < len(args):
-        if args[i] in ("-e", "--existing") and i + 1 < len(args):
+        if args[i] in ("-e", "--existing"):
+            if i + 1 >= len(args):
+                print(f"Missing value for {args[i]}", file=sys.stderr); sys.exit(1)
             existing_path = Path(args[i + 1]); i += 2
-        elif args[i] in ("-t", "--torrent") and i + 1 < len(args):
+        elif args[i] in ("-t", "--torrent"):
+            if i + 1 >= len(args):
+                print(f"Missing value for {args[i]}", file=sys.stderr); sys.exit(1)
             torrent_path = Path(args[i + 1]); i += 2
-        elif args[i] in ("-n", "--nas") and i + 1 < len(args):
+        elif args[i] == "--nas":
+            if i + 1 >= len(args):
+                print(f"Missing value for {args[i]}", file=sys.stderr); sys.exit(1)
             nas_path = Path(args[i + 1]); i += 2
         elif args[i] == "--dry-run":
             dry_run = True; i += 1

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -155,6 +155,37 @@ def phase_copy_new(torrent_path: Path, existing_path: Path,
     return count
 
 
+def phase_replace_matched(torrent_path: Path, existing_path: Path,
+                           matched_dates: list, ex_dated: dict, tr_dated: dict,
+                           dry_run: bool) -> int:
+    count = 0
+    for date in matched_dates:
+        for tr_dirname in tr_dated[date]:
+            src = torrent_path / tr_dirname
+            dst = existing_path / tr_dirname
+
+            if dst.exists():
+                print(f"  [Phase 3] SKIP copy {tr_dirname} (already exists)")
+            elif dry_run:
+                print(f"  [Phase 3 - DRY RUN] cp -r {tr_dirname} → {existing_path}/")
+            else:
+                print(f"  [Phase 3] Copying   {tr_dirname}")
+                shutil.copytree(src, dst)
+
+            for old_name in ex_dated[date]:
+                old = existing_path / old_name
+                if old == dst:
+                    continue
+                if dry_run:
+                    print(f"  [Phase 3 - DRY RUN] rm -rf {old_name}")
+                elif old.exists():
+                    print(f"  [Phase 3] Removing  {old_name}")
+                    shutil.rmtree(old)
+
+            count += 1
+    return count
+
+
 def parse_args(argv):
     existing_path = DEFAULT_EXISTING
     torrent_path  = DEFAULT_TORRENT

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -117,6 +117,25 @@ def preflight(existing_path: Path, torrent_path: Path, nas_path, execute: bool):
         sys.exit(1)
 
 
+def phase_backup(existing_path: Path, nas_path, dry_run: bool):
+    if dry_run:
+        if nas_path is None:
+            print("  [Phase 1 - DRY RUN] Would rsync existing → <nas-path> (provide --nas with --execute)")
+        else:
+            cmd = ["rsync", "--archive", "--verbose", "--progress", "--human-readable",
+                   f"{existing_path}/", str(nas_path)]
+            print(f"  [Phase 1 - DRY RUN] Would run: {' '.join(cmd)}")
+        return
+    cmd = ["rsync", "--archive", "--verbose", "--progress", "--human-readable",
+           f"{existing_path}/", str(nas_path)]
+    print(f"  [Phase 1] Backing up {existing_path} → {nas_path} ...")
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(f"  {red('Error:')} rsync failed (exit {result.returncode})", file=sys.stderr)
+        sys.exit(1)
+    print(f"  [Phase 1] Backup complete.\n")
+
+
 def parse_args(argv):
     existing_path = DEFAULT_EXISTING
     torrent_path  = DEFAULT_TORRENT

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -186,6 +186,27 @@ def phase_replace_matched(torrent_path: Path, existing_path: Path,
     return count
 
 
+def phase_rename_existing(existing_path: Path, ex_only_dates: list,
+                           ex_dated: dict, dry_run: bool) -> int:
+    count = 0
+    for date in ex_only_dates:
+        for dirname in ex_dated[date]:
+            if dirname.startswith(f"Phish-{date}."):
+                continue
+            new_name = existing_to_torrent_name(dirname, date)
+            src = existing_path / dirname
+            dst = existing_path / new_name
+            if src == dst:
+                continue
+            if dry_run:
+                print(f"  [Phase 4 - DRY RUN] mv {dirname} → {new_name}")
+            else:
+                print(f"  [Phase 4] Renaming  {dirname} → {new_name}")
+                src.rename(dst)
+            count += 1
+    return count
+
+
 def parse_args(argv):
     existing_path = DEFAULT_EXISTING
     torrent_path  = DEFAULT_TORRENT

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -92,7 +92,7 @@ def load(path: Path, extractor):
 def existing_to_torrent_name(dirname: str, date: str) -> str:
     """Convert an existing-style dirname to Phish-YYYY-MM-DD.Dot.Separated.Location."""
     name = dirname
-    name = re.sub(r'^\d{4}[-_]\d{1,2}[-_]\d{1,2}\s*', '', name)  # strip YYYY[-_]MM[-_]DD
+    name = re.sub(r'^\d{4}[-_]\d{1,2}[-_]\d{1,2}[-_]?\s*', '', name)  # strip YYYY[-_]MM[-_]DD[_]
     name = re.sub(r'^\d{1,2}_\d{1,2}_\d{4}\s*', '', name)         # strip M_DD_YYYY
     name = re.sub(r'^-\s*', '', name).strip()                       # strip leading ' - '
     name = name.replace(',', '')                                    # remove commas

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -89,6 +89,17 @@ def load(path: Path, extractor):
     return dated, undated
 
 
+def existing_to_torrent_name(dirname: str, date: str) -> str:
+    """Convert an existing-style dirname to Phish-YYYY-MM-DD.Dot.Separated.Location."""
+    name = dirname
+    name = re.sub(r'^\d{4}[-_]\d{1,2}[-_]\d{1,2}\s*', '', name)  # strip YYYY[-_]MM[-_]DD
+    name = re.sub(r'^\d{1,2}_\d{1,2}_\d{4}\s*', '', name)         # strip M_DD_YYYY
+    name = re.sub(r'^-\s*', '', name).strip()                       # strip leading ' - '
+    name = name.replace(',', '')                                    # remove commas
+    name = re.sub(r'\s+', '.', name.strip()).strip('.')             # spaces → dots
+    return f"Phish-{date}.{name}"
+
+
 def parse_args(argv):
     existing_path = DEFAULT_EXISTING
     torrent_path  = DEFAULT_TORRENT

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -136,6 +136,25 @@ def phase_backup(existing_path: Path, nas_path, dry_run: bool):
     print(f"  [Phase 1] Backup complete.\n")
 
 
+def phase_copy_new(torrent_path: Path, existing_path: Path,
+                   tr_only_dates: list, tr_dated: dict, dry_run: bool) -> int:
+    count = 0
+    for date in tr_only_dates:
+        for dirname in tr_dated[date]:
+            src = torrent_path / dirname
+            dst = existing_path / dirname
+            if dst.exists():
+                print(f"  [Phase 2] SKIP {dirname} (destination already exists)")
+                continue
+            if dry_run:
+                print(f"  [Phase 2 - DRY RUN] cp -r {dirname} → {existing_path}/")
+            else:
+                print(f"  [Phase 2] Copying  {dirname}")
+                shutil.copytree(src, dst)
+            count += 1
+    return count
+
+
 def parse_args(argv):
     existing_path = DEFAULT_EXISTING
     torrent_path  = DEFAULT_TORRENT

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -51,6 +51,44 @@ def green(s):  return _ansi("92", s)
 def yellow(s): return _ansi("93", s)
 
 
+# ── Date extraction ────────────────────────────────────────────────────────────
+
+def date_from_existing(name: str):
+    m = re.match(r'^(\d{4})[-_](\d{1,2})[-_](\d{1,2})', name)
+    if m:
+        y, mo, d = m.group(1), int(m.group(2)), int(m.group(3))
+        return f"{y}-{mo:02d}-{d:02d}"
+    m = re.match(r'^(\d{1,2})_(\d{1,2})_(\d{4})\b', name)
+    if m:
+        mo, d, y = int(m.group(1)), int(m.group(2)), m.group(3)
+        return f"{y}-{mo:02d}-{d:02d}"
+    return None
+
+
+def date_from_torrent(name: str):
+    m = re.match(r'^Phish-(\d{4})-(\d{2})-(\d{2})\.', name)
+    if m:
+        return f"{m.group(1)}-{m.group(2)}-{m.group(3)}"
+    return None
+
+
+def load(path: Path, extractor):
+    dated   = defaultdict(list)
+    undated = []
+    if not path.exists():
+        print(f"  {red('Error:')} path does not exist: {path}", file=sys.stderr)
+        sys.exit(1)
+    for entry in sorted(path.iterdir(), key=lambda e: e.name.lower()):
+        if entry.name.startswith('.') or not entry.is_dir():
+            continue
+        date = extractor(entry.name)
+        if date:
+            dated[date].append(entry.name)
+        else:
+            undated.append(entry.name)
+    return dated, undated
+
+
 def parse_args(argv):
     existing_path = DEFAULT_EXISTING
     torrent_path  = DEFAULT_TORRENT

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -39,6 +39,10 @@ class TestDateFromExisting:
     def test_no_match_returns_none(self):
         assert pm.date_from_existing("Live Bait Vol 10") is None
 
+    def test_legacy_m_dd_yyyy_dash_not_supported(self):
+        # legacy format only supports underscore separators, not dashes
+        assert pm.date_from_existing("7-13-1994 Big Birch Concert Theatre") is None
+
 
 class TestDateFromTorrent:
     def test_standard_format(self):
@@ -68,6 +72,15 @@ class TestLoad:
     def test_skips_dotfiles(self, tmp_path):
         (tmp_path / ".DS_Store").mkdir()
         (tmp_path / "2024_07_20 Mansfield, MA").mkdir()
+
+        dated, undated = pm.load(tmp_path, pm.date_from_existing)
+
+        assert len(dated) == 1
+        assert len(undated) == 0
+
+    def test_skips_plain_files(self, tmp_path):
+        (tmp_path / "2024_07_20 Mansfield, MA").mkdir()
+        (tmp_path / "README.txt").write_text("notes")  # plain file, not a dir
 
         dated, undated = pm.load(tmp_path, pm.date_from_existing)
 

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -314,3 +314,38 @@ class TestPhaseReplaceMatched:
         assert not (existing / "2009-11-27 Albany, NY").exists()
         assert not (existing / ex_dir2).exists()
         assert (existing / tr_dir).exists()
+
+
+class TestPhaseRenameExisting:
+    def test_dry_run_prints_and_touches_nothing(self, tmp_path, capsys):
+        ex_dir = "2009-11-27 Albany, NY"
+        (tmp_path / ex_dir).mkdir()
+        ex_dated = {"2009-11-27": [ex_dir]}
+
+        pm.phase_rename_existing(tmp_path, ["2009-11-27"], ex_dated, dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert "Phish-2009-11-27.Albany.NY" in out
+        assert (tmp_path / ex_dir).exists()  # nothing moved
+
+    def test_execute_renames_directory(self, tmp_path):
+        ex_dir = "2009-11-27 Albany, NY"
+        (tmp_path / ex_dir).mkdir()
+        ex_dated = {"2009-11-27": [ex_dir]}
+
+        count = pm.phase_rename_existing(tmp_path, ["2009-11-27"], ex_dated, dry_run=False)
+
+        assert count == 1
+        assert not (tmp_path / ex_dir).exists()
+        assert (tmp_path / "Phish-2009-11-27.Albany.NY").exists()
+
+    def test_skips_already_correctly_named(self, tmp_path):
+        ex_dir = "Phish-2009-11-27.Albany.NY"
+        (tmp_path / ex_dir).mkdir()
+        ex_dated = {"2009-11-27": [ex_dir]}
+
+        count = pm.phase_rename_existing(tmp_path, ["2009-11-27"], ex_dated, dry_run=False)
+
+        assert count == 0
+        assert (tmp_path / ex_dir).exists()

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -117,3 +117,29 @@ class TestExistingToTorrentName:
         assert pm.existing_to_torrent_name(
             "7_13_1994 Big Birch Concert Theatre, Patterson, NY", "1994-07-13"
         ) == "Phish-1994-07-13.Big.Birch.Concert.Theatre.Patterson.NY"
+
+
+class TestPreflight:
+    def test_missing_existing_path_exits(self, tmp_path):
+        with pytest.raises(SystemExit):
+            pm.preflight(tmp_path / "nonexistent", tmp_path, None, execute=False)
+
+    def test_missing_torrent_path_exits(self, tmp_path):
+        with pytest.raises(SystemExit):
+            pm.preflight(tmp_path, tmp_path / "nonexistent", None, execute=False)
+
+    def test_execute_without_nas_exits(self, tmp_path):
+        with pytest.raises(SystemExit):
+            pm.preflight(tmp_path, tmp_path, None, execute=True)
+
+    def test_execute_with_missing_nas_exits(self, tmp_path):
+        with pytest.raises(SystemExit):
+            pm.preflight(tmp_path, tmp_path, tmp_path / "nonexistent", execute=True)
+
+    def test_valid_dry_run_does_not_exit(self, tmp_path):
+        pm.preflight(tmp_path, tmp_path, None, execute=False)  # must not raise
+
+    def test_valid_execute_does_not_exit(self, tmp_path):
+        nas = tmp_path / "nas"
+        nas.mkdir()
+        pm.preflight(tmp_path, tmp_path, nas, execute=True)  # must not raise

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -90,3 +90,30 @@ class TestLoad:
     def test_missing_path_exits(self, tmp_path):
         with pytest.raises(SystemExit):
             pm.load(tmp_path / "nonexistent", pm.date_from_existing)
+
+
+class TestExistingToTorrentName:
+    def test_simple_city_state(self):
+        assert pm.existing_to_torrent_name(
+            "2009-11-27 Albany, NY", "2009-11-27"
+        ) == "Phish-2009-11-27.Albany.NY"
+
+    def test_with_dash_separator(self):
+        assert pm.existing_to_torrent_name(
+            "1995-06-19 - Deer Creek Music Center, Noblesville, IN", "1995-06-19"
+        ) == "Phish-1995-06-19.Deer.Creek.Music.Center.Noblesville.IN"
+
+    def test_underscore_date(self):
+        assert pm.existing_to_torrent_name(
+            "2024_07_20 Mansfield, MA", "2024-07-20"
+        ) == "Phish-2024-07-20.Mansfield.MA"
+
+    def test_single_digit_day(self):
+        assert pm.existing_to_torrent_name(
+            "1994_12_6 Goleta, CA", "1994-12-06"
+        ) == "Phish-1994-12-06.Goleta.CA"
+
+    def test_legacy_m_dd_yyyy(self):
+        assert pm.existing_to_torrent_name(
+            "7_13_1994 Big Birch Concert Theatre, Patterson, NY", "1994-07-13"
+        ) == "Phish-1994-07-13.Big.Birch.Concert.Theatre.Patterson.NY"

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -349,3 +349,62 @@ class TestPhaseRenameExisting:
 
         assert count == 0
         assert (tmp_path / ex_dir).exists()
+
+
+class TestEndToEnd:
+    def _build_collection(self, tmp_path):
+        existing = tmp_path / "existing"
+        torrent  = tmp_path / "torrent"
+        existing.mkdir()
+        torrent.mkdir()
+
+        # Matched show: in both collections
+        (existing / "2009-11-27 Albany, NY").mkdir()
+        tr_matched = torrent / "Phish-2009-11-27.Times.Union.Center.Albany.NY.[515]"
+        tr_matched.mkdir()
+        (tr_matched / "track01.flac").write_text("flac")
+
+        # Torrent-only show
+        tr_new = torrent / "Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]"
+        tr_new.mkdir()
+        (tr_new / "track01.flac").write_text("flac")
+
+        # Existing-only show
+        (existing / "1995-06-19 - Deer Creek Music Center, Noblesville, IN").mkdir()
+
+        return existing, torrent
+
+    def test_dry_run_covers_all_phases_and_touches_nothing(self, tmp_path, capsys):
+        existing, torrent = self._build_collection(tmp_path)
+
+        pm.main_logic(existing, torrent, nas_path=None, dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "Phase 1" in out
+        assert "Phase 2" in out
+        assert "Phase 3" in out
+        assert "Phase 4" in out
+        assert "DRY RUN" in out
+        # Disk untouched
+        assert (existing / "2009-11-27 Albany, NY").exists()
+        assert (existing / "1995-06-19 - Deer Creek Music Center, Noblesville, IN").exists()
+        assert not (existing / "Phish-2009-11-27.Times.Union.Center.Albany.NY.[515]").exists()
+
+    def test_execute_performs_full_merge(self, tmp_path, capsys):
+        existing, torrent = self._build_collection(tmp_path)
+        nas = tmp_path / "nas"
+        nas.mkdir()
+
+        from unittest.mock import patch
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            pm.main_logic(existing, torrent, nas_path=nas, dry_run=False)
+
+        # Torrent-only show was copied
+        assert (existing / "Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]" / "track01.flac").exists()
+        # Matched show: torrent canonical present, old gone
+        assert (existing / "Phish-2009-11-27.Times.Union.Center.Albany.NY.[515]" / "track01.flac").exists()
+        assert not (existing / "2009-11-27 Albany, NY").exists()
+        # Existing-only show was renamed
+        assert not (existing / "1995-06-19 - Deer Creek Music Center, Noblesville, IN").exists()
+        assert (existing / "Phish-1995-06-19.Deer.Creek.Music.Center.Noblesville.IN").exists()

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -198,3 +198,50 @@ class TestPhaseBackup:
             mock_run.return_value.returncode = 1
             with pytest.raises(SystemExit):
                 pm.phase_backup(existing, nas, dry_run=False)
+
+
+class TestPhaseCopyNew:
+    def _make_show(self, parent, dirname):
+        show = parent / dirname
+        show.mkdir(parents=True)
+        (show / "track01.flac").write_text("audio")
+
+    def test_dry_run_prints_and_touches_nothing(self, tmp_path, capsys):
+        torrent  = tmp_path / "torrent"
+        existing = tmp_path / "existing"
+        existing.mkdir()
+        self._make_show(torrent, "Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]")
+
+        tr_dated = {"2024-07-20": ["Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]"]}
+        pm.phase_copy_new(torrent, existing, ["2024-07-20"], tr_dated, dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert "Phish-2024-07-20" in out
+        assert not (existing / "Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]").exists()
+
+    def test_execute_copies_directory(self, tmp_path):
+        torrent  = tmp_path / "torrent"
+        existing = tmp_path / "existing"
+        existing.mkdir()
+        self._make_show(torrent, "Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]")
+
+        tr_dated = {"2024-07-20": ["Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]"]}
+        count = pm.phase_copy_new(torrent, existing, ["2024-07-20"], tr_dated, dry_run=False)
+
+        assert count == 1
+        assert (existing / "Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]" / "track01.flac").exists()
+
+    def test_skips_if_destination_exists(self, tmp_path, capsys):
+        torrent  = tmp_path / "torrent"
+        existing = tmp_path / "existing"
+        existing.mkdir()
+        dirname = "Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]"
+        self._make_show(torrent, dirname)
+        (existing / dirname).mkdir()  # already present
+
+        tr_dated = {"2024-07-20": [dirname]}
+        count = pm.phase_copy_new(torrent, existing, ["2024-07-20"], tr_dated, dry_run=False)
+
+        assert count == 0
+        assert "SKIP" in capsys.readouterr().out

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -1,0 +1,79 @@
+import importlib.util
+import sys
+import pytest
+from pathlib import Path
+import tempfile
+
+
+def load_module():
+    from importlib.machinery import SourceFileLoader
+    path = Path(__file__).parent.parent / "bin" / "phish-merge"
+    loader = SourceFileLoader("phish_merge", str(path))
+    spec = importlib.util.spec_from_loader("phish_merge", loader)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+pm = load_module()
+
+
+class TestDateFromExisting:
+    def test_yyyy_mm_dd_space_city(self):
+        assert pm.date_from_existing("2009-11-27 Albany, NY") == "2009-11-27"
+
+    def test_yyyy_underscore_mm_dd(self):
+        assert pm.date_from_existing("2024_07_20 Mansfield, MA") == "2024-07-20"
+
+    def test_with_dash_separator(self):
+        assert pm.date_from_existing(
+            "1995-06-19 - Deer Creek Music Center, Noblesville, IN"
+        ) == "1995-06-19"
+
+    def test_single_digit_day(self):
+        assert pm.date_from_existing("1994_12_6 Goleta, CA") == "1994-12-06"
+
+    def test_legacy_m_dd_yyyy(self):
+        assert pm.date_from_existing("7_13_1994 Big Birch Concert Theatre") == "1994-07-13"
+
+    def test_no_match_returns_none(self):
+        assert pm.date_from_existing("Live Bait Vol 10") is None
+
+
+class TestDateFromTorrent:
+    def test_standard_format(self):
+        assert pm.date_from_torrent(
+            "Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]"
+        ) == "2024-07-20"
+
+    def test_no_phish_prefix(self):
+        assert pm.date_from_torrent("2024-07-20.Xfinity.Center") is None
+
+    def test_studio_album_no_match(self):
+        assert pm.date_from_torrent("Phish-Farmhouse.[439]") is None
+
+
+class TestLoad:
+    def test_splits_dated_and_undated(self, tmp_path):
+        (tmp_path / "2024_07_20 Mansfield, MA").mkdir()
+        (tmp_path / "2009-11-27 Albany, NY").mkdir()
+        (tmp_path / "Live Bait Vol 10").mkdir()
+
+        dated, undated = pm.load(tmp_path, pm.date_from_existing)
+
+        assert "2024-07-20" in dated
+        assert "2009-11-27" in dated
+        assert "Live Bait Vol 10" in undated
+
+    def test_skips_dotfiles(self, tmp_path):
+        (tmp_path / ".DS_Store").mkdir()
+        (tmp_path / "2024_07_20 Mansfield, MA").mkdir()
+
+        dated, undated = pm.load(tmp_path, pm.date_from_existing)
+
+        assert len(dated) == 1
+        assert len(undated) == 0
+
+    def test_missing_path_exits(self, tmp_path):
+        with pytest.raises(SystemExit):
+            pm.load(tmp_path / "nonexistent", pm.date_from_existing)

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -143,3 +143,58 @@ class TestPreflight:
         nas = tmp_path / "nas"
         nas.mkdir()
         pm.preflight(tmp_path, tmp_path, nas, execute=True)  # must not raise
+
+
+from unittest.mock import patch
+
+
+class TestPhaseBackup:
+    def test_dry_run_with_nas_prints_rsync_command(self, tmp_path, capsys):
+        existing = tmp_path / "existing"
+        existing.mkdir()
+        nas = tmp_path / "nas"
+
+        pm.phase_backup(existing, nas, dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "Phase 1" in out
+        assert "DRY RUN" in out
+        assert "rsync" in out
+        assert str(existing) in out
+
+    def test_dry_run_with_none_nas_prints_placeholder(self, tmp_path, capsys):
+        existing = tmp_path / "existing"
+        existing.mkdir()
+
+        pm.phase_backup(existing, None, dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "Phase 1" in out
+        assert "DRY RUN" in out
+
+    def test_execute_calls_rsync(self, tmp_path):
+        existing = tmp_path / "existing"
+        existing.mkdir()
+        nas = tmp_path / "nas"
+        nas.mkdir()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            pm.phase_backup(existing, nas, dry_run=False)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "rsync" in cmd
+        assert f"{existing}/" in cmd
+        assert str(nas) in cmd
+
+    def test_execute_exits_on_rsync_failure(self, tmp_path):
+        existing = tmp_path / "existing"
+        existing.mkdir()
+        nas = tmp_path / "nas"
+        nas.mkdir()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+            with pytest.raises(SystemExit):
+                pm.phase_backup(existing, nas, dry_run=False)

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -272,7 +272,8 @@ class TestPhaseReplaceMatched:
         out = capsys.readouterr().out
         assert "DRY RUN" in out
         assert tr_dir in out
-        assert (existing / ex_dir).exists()  # nothing deleted
+        assert (existing / ex_dir).exists()       # nothing deleted
+        assert not (existing / tr_dir).exists()   # nothing copied
 
     def test_execute_copies_torrent_and_removes_old(self, tmp_path):
         torrent, existing, tr_dir, ex_dir = self._setup(tmp_path)

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -245,3 +245,72 @@ class TestPhaseCopyNew:
 
         assert count == 0
         assert "SKIP" in capsys.readouterr().out
+
+
+class TestPhaseReplaceMatched:
+    def _setup(self, tmp_path):
+        torrent  = tmp_path / "torrent"
+        existing = tmp_path / "existing"
+        existing.mkdir()
+        tr_dir = "Phish-2009-11-27.Times.Union.Center.Albany.NY.[515]"
+        ex_dir = "2009-11-27 Albany, NY"
+        tr_show = torrent / tr_dir
+        tr_show.mkdir(parents=True)
+        (tr_show / "track01.flac").write_text("flac")
+        ex_show = existing / ex_dir
+        ex_show.mkdir()
+        (ex_show / "track01.mp3").write_text("mp3")
+        return torrent, existing, tr_dir, ex_dir
+
+    def test_dry_run_prints_and_touches_nothing(self, tmp_path, capsys):
+        torrent, existing, tr_dir, ex_dir = self._setup(tmp_path)
+        ex_dated = {"2009-11-27": [ex_dir]}
+        tr_dated = {"2009-11-27": [tr_dir]}
+
+        pm.phase_replace_matched(torrent, existing, ["2009-11-27"], ex_dated, tr_dated, dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert tr_dir in out
+        assert (existing / ex_dir).exists()  # nothing deleted
+
+    def test_execute_copies_torrent_and_removes_old(self, tmp_path):
+        torrent, existing, tr_dir, ex_dir = self._setup(tmp_path)
+        ex_dated = {"2009-11-27": [ex_dir]}
+        tr_dated = {"2009-11-27": [tr_dir]}
+
+        count = pm.phase_replace_matched(
+            torrent, existing, ["2009-11-27"], ex_dated, tr_dated, dry_run=False
+        )
+
+        assert count == 1
+        assert (existing / tr_dir / "track01.flac").exists()
+        assert not (existing / ex_dir).exists()
+
+    def test_skips_copy_if_dst_exists_but_still_removes_old(self, tmp_path):
+        torrent, existing, tr_dir, ex_dir = self._setup(tmp_path)
+        (existing / tr_dir).mkdir()  # destination already exists
+        ex_dated = {"2009-11-27": [ex_dir]}
+        tr_dated = {"2009-11-27": [tr_dir]}
+
+        pm.phase_replace_matched(
+            torrent, existing, ["2009-11-27"], ex_dated, tr_dated, dry_run=False
+        )
+
+        assert (existing / tr_dir).exists()
+        assert not (existing / ex_dir).exists()
+
+    def test_removes_all_old_dirs_for_date(self, tmp_path):
+        torrent, existing, tr_dir, _ = self._setup(tmp_path)
+        ex_dir2 = "2009-11-27 Albany NY (alt)"
+        (existing / ex_dir2).mkdir()
+        ex_dated = {"2009-11-27": ["2009-11-27 Albany, NY", ex_dir2]}
+        tr_dated = {"2009-11-27": [tr_dir]}
+
+        pm.phase_replace_matched(
+            torrent, existing, ["2009-11-27"], ex_dated, tr_dated, dry_run=False
+        )
+
+        assert not (existing / "2009-11-27 Albany, NY").exists()
+        assert not (existing / ex_dir2).exists()
+        assert (existing / tr_dir).exists()


### PR DESCRIPTION
## Summary

- Adds `bin/phish-merge`, a Python CLI that merges an existing Phish live show collection with a LivePhish torrent download
- Runs five phases in order: pre-flight checks → NAS backup (rsync) → copy torrent-only shows → replace matched shows with canonical torrent copies → rename existing-only shows to torrent naming style
- Defaults to `--dry-run`; requires explicit `--execute --nas PATH` to touch disk
- 41 pytest tests covering all phases, edge cases, and end-to-end dry-run/execute flows

## What it does

```
bin/phish-merge [--dry-run]
bin/phish-merge --execute --nas PATH
bin/phish-merge --existing PATH --torrent PATH --execute --nas PATH
```

**Naming convention:** All shows standardize to torrent style (`Phish-YYYY-MM-DD.Venue.City.State.[ID]`). Existing-only shows get `Phish-YYYY-MM-DD.Venue.City.State` (no ID suffix).

**Safety:** Torrent source is never modified (copy-only). Phase 1 NAS backup must succeed before phases 2–4 run. Phase 3 copy completes before old directories are deleted.

## Test plan

- [x] Run `python3 -m pytest tests/test_phish_merge.py -v` — all 41 tests pass
- [x] Run dry-run against synthetic test directories (see README for setup steps)
- [x] Run dry-run against real collection paths and review output before executing

🤖 Generated with [Claude Code](https://claude.com/claude-code)