### PR TITLE
feat: add --phase N flag to phish-merge

### DIFF
--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -9,11 +9,13 @@ Usage:
   phish-merge [--dry-run]
   phish-merge --execute --nas PATH
   phish-merge --existing PATH --torrent PATH --execute --nas PATH
+  phish-merge --phase N [--dry-run | --execute --nas PATH]
 
 Options:
   -e, --existing PATH   Existing live collection path
   -t, --torrent  PATH   Torrent directory path
       --nas      PATH   NAS backup destination (required with --execute)
+      --phase    N      Run only phase N (1=backup, 2=copy-new, 3=replace, 4=rename)
       --dry-run         Print planned actions, touch nothing [default]
       --execute         Perform the actual merge
   -h, --help            Show this message
@@ -224,7 +226,8 @@ def phase_summary(new_count: int, replaced_count: int, renamed_count: int,
     print()
 
 
-def main_logic(existing_path: Path, torrent_path: Path, nas_path, dry_run: bool):
+def main_logic(existing_path: Path, torrent_path: Path, nas_path, dry_run: bool,
+               phase: int = None):
     ex_dated, _ex_undated = load(existing_path, date_from_existing)
     tr_dated, _tr_undated = load(torrent_path,  date_from_torrent)
 
@@ -238,10 +241,21 @@ def main_logic(existing_path: Path, torrent_path: Path, nas_path, dry_run: bool)
           f"{len(matched_dates)} matched  ·  {len(ex_only_dates)} existing-only  ·  "
           f"{len(tr_only_dates)} torrent-only\n")
 
-    phase_backup(existing_path, nas_path, dry_run)
-    new_count      = phase_copy_new(torrent_path, existing_path, tr_only_dates, tr_dated, dry_run)
-    replaced_count = phase_replace_matched(torrent_path, existing_path, matched_dates, ex_dated, tr_dated, dry_run)
-    renamed_count  = phase_rename_existing(existing_path, ex_only_dates, ex_dated, dry_run)
+    if phase is None or phase == 1:
+        phase_backup(existing_path, nas_path, dry_run)
+
+    new_count = 0
+    if phase is None or phase == 2:
+        new_count = phase_copy_new(torrent_path, existing_path, tr_only_dates, tr_dated, dry_run)
+
+    replaced_count = 0
+    if phase is None or phase == 3:
+        replaced_count = phase_replace_matched(torrent_path, existing_path, matched_dates, ex_dated, tr_dated, dry_run)
+
+    renamed_count = 0
+    if phase is None or phase == 4:
+        renamed_count = phase_rename_existing(existing_path, ex_only_dates, ex_dated, dry_run)
+
     phase_summary(new_count, replaced_count, renamed_count, existing_path, dry_run)
 
 
@@ -294,16 +308,17 @@ def parse_args(argv):
 
 
 def main():
-    existing_path, torrent_path, nas_path, dry_run = parse_args(sys.argv)
+    existing_path, torrent_path, nas_path, dry_run, phase = parse_args(sys.argv)
     mode = "DRY RUN" if dry_run else "EXECUTE"
-    print(f"\n  {bold('PHISH MERGE')}  [{mode}]")
+    phase_label = f" · PHASE {phase}" if phase is not None else ""
+    print(f"\n  {bold('PHISH MERGE')}  [{mode}{phase_label}]")
     print(f"  {dim('Existing:')}  {existing_path}")
     print(f"  {dim('Torrent: ')}  {torrent_path}")
     if not dry_run:
         print(f"  {dim('NAS:     ')}  {nas_path}")
     print()
     preflight(existing_path, torrent_path, nas_path, not dry_run)
-    main_logic(existing_path, torrent_path, nas_path, dry_run)
+    main_logic(existing_path, torrent_path, nas_path, dry_run, phase)
 
 
 if __name__ == "__main__":

--- a/bin/phish-merge
+++ b/bin/phish-merge
@@ -250,6 +250,7 @@ def parse_args(argv):
     torrent_path  = DEFAULT_TORRENT
     nas_path      = None
     dry_run       = True
+    phase         = None
 
     args = argv[1:]
     i = 0
@@ -266,6 +267,18 @@ def parse_args(argv):
             if i + 1 >= len(args):
                 print(f"Missing value for {args[i]}", file=sys.stderr); sys.exit(1)
             nas_path = Path(args[i + 1]); i += 2
+        elif args[i] == "--phase":
+            if i + 1 >= len(args):
+                print(f"Missing value for {args[i]}", file=sys.stderr); sys.exit(1)
+            try:
+                phase = int(args[i + 1])
+            except ValueError:
+                print(f"--phase requires an integer 1-4, got: {args[i+1]}", file=sys.stderr)
+                sys.exit(1)
+            if phase not in (1, 2, 3, 4):
+                print(f"--phase must be 1-4, got: {phase}", file=sys.stderr)
+                sys.exit(1)
+            i += 2
         elif args[i] == "--dry-run":
             dry_run = True; i += 1
         elif args[i] == "--execute":
@@ -277,7 +290,7 @@ def parse_args(argv):
             print(f"Unknown argument: {args[i]}", file=sys.stderr)
             sys.exit(1)
 
-    return existing_path, torrent_path, nas_path, dry_run
+    return existing_path, torrent_path, nas_path, dry_run, phase
 
 
 def main():

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -145,6 +145,40 @@ class TestPreflight:
         pm.preflight(tmp_path, tmp_path, nas, execute=True)  # must not raise
 
 
+class TestParseArgsPhase:
+    def test_no_phase_returns_none(self):
+        _, _, _, _, phase = pm.parse_args(["phish-merge"])
+        assert phase is None
+
+    def test_phase_flag_returns_integer(self):
+        _, _, _, _, phase = pm.parse_args(["phish-merge", "--phase", "2"])
+        assert phase == 2
+
+    def test_phase_one_accepted(self):
+        _, _, _, _, phase = pm.parse_args(["phish-merge", "--phase", "1"])
+        assert phase == 1
+
+    def test_phase_four_accepted(self):
+        _, _, _, _, phase = pm.parse_args(["phish-merge", "--phase", "4"])
+        assert phase == 4
+
+    def test_phase_zero_exits(self):
+        with pytest.raises(SystemExit):
+            pm.parse_args(["phish-merge", "--phase", "0"])
+
+    def test_phase_five_exits(self):
+        with pytest.raises(SystemExit):
+            pm.parse_args(["phish-merge", "--phase", "5"])
+
+    def test_phase_non_integer_exits(self):
+        with pytest.raises(SystemExit):
+            pm.parse_args(["phish-merge", "--phase", "backup"])
+
+    def test_missing_phase_value_exits(self):
+        with pytest.raises(SystemExit):
+            pm.parse_args(["phish-merge", "--phase"])
+
+
 from unittest.mock import patch
 
 

--- a/tests/test_phish_merge.py
+++ b/tests/test_phish_merge.py
@@ -443,3 +443,73 @@ class TestEndToEnd:
         # Existing-only show was renamed
         assert not (existing / "1995-06-19 - Deer Creek Music Center, Noblesville, IN").exists()
         assert (existing / "Phish-1995-06-19.Deer.Creek.Music.Center.Noblesville.IN").exists()
+
+
+class TestMainLogicPhaseFilter:
+    def _build_collection(self, tmp_path):
+        existing = tmp_path / "existing"
+        torrent  = tmp_path / "torrent"
+        existing.mkdir()
+        torrent.mkdir()
+        (existing / "2009-11-27 Albany, NY").mkdir()
+        tr_matched = torrent / "Phish-2009-11-27.Times.Union.Center.Albany.NY.[515]"
+        tr_matched.mkdir()
+        (tr_matched / "track01.flac").write_text("flac")
+        tr_new = torrent / "Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]"
+        tr_new.mkdir()
+        (tr_new / "track01.flac").write_text("flac")
+        (existing / "1995-06-19 - Deer Creek Music Center, Noblesville, IN").mkdir()
+        return existing, torrent
+
+    def test_no_phase_runs_all_phases(self, tmp_path, capsys):
+        existing, torrent = self._build_collection(tmp_path)
+        pm.main_logic(existing, torrent, nas_path=None, dry_run=True, phase=None)
+        out = capsys.readouterr().out
+        assert "Phase 1" in out
+        assert "Phase 2" in out
+        assert "Phase 3" in out
+        assert "Phase 4" in out
+
+    def test_phase_1_runs_only_backup(self, tmp_path, capsys):
+        existing, torrent = self._build_collection(tmp_path)
+        pm.main_logic(existing, torrent, nas_path=None, dry_run=True, phase=1)
+        out = capsys.readouterr().out
+        assert "Phase 1" in out
+        assert "Phase 2" not in out
+        assert "Phase 3" not in out
+        assert "Phase 4" not in out
+
+    def test_phase_2_runs_only_copy_new(self, tmp_path, capsys):
+        existing, torrent = self._build_collection(tmp_path)
+        pm.main_logic(existing, torrent, nas_path=None, dry_run=True, phase=2)
+        out = capsys.readouterr().out
+        assert "Phase 2" in out
+        assert "Phase 1" not in out
+        assert "Phase 3" not in out
+        assert "Phase 4" not in out
+
+    def test_phase_3_runs_only_replace_matched(self, tmp_path, capsys):
+        existing, torrent = self._build_collection(tmp_path)
+        pm.main_logic(existing, torrent, nas_path=None, dry_run=True, phase=3)
+        out = capsys.readouterr().out
+        assert "Phase 3" in out
+        assert "Phase 1" not in out
+        assert "Phase 2" not in out
+        assert "Phase 4" not in out
+
+    def test_phase_4_runs_only_rename_existing(self, tmp_path, capsys):
+        existing, torrent = self._build_collection(tmp_path)
+        pm.main_logic(existing, torrent, nas_path=None, dry_run=True, phase=4)
+        out = capsys.readouterr().out
+        assert "Phase 4" in out
+        assert "Phase 1" not in out
+        assert "Phase 2" not in out
+        assert "Phase 3" not in out
+
+    def test_phase_4_execute_only_renames(self, tmp_path):
+        existing, torrent = self._build_collection(tmp_path)
+        pm.main_logic(existing, torrent, nas_path=None, dry_run=False, phase=4)
+        assert (existing / "Phish-1995-06-19.Deer.Creek.Music.Center.Noblesville.IN").exists()
+        assert not (existing / "1995-06-19 - Deer Creek Music Center, Noblesville, IN").exists()
+        assert not (existing / "Phish-2024-07-20.Xfinity.Center.Mansfield.MA.[2260]").exists()
+        assert (existing / "2009-11-27 Albany, NY").exists()


### PR DESCRIPTION
## Summary
- Adds `--phase N` (1–4) flag to run a single phase and return to the prompt between phases
- Preflight checks always run regardless of `--phase`
- Omitting `--phase` preserves existing all-phases behavior

## Test Plan
- [x] `python -m pytest tests/test_phish_merge.py -v` — all 55 tests pass
- [x] `bin/phish-merge --phase 2 --dry-run` — prints only Phase 2 output
- [x] `bin/phish-merge --phase 5` — exits with error "must be 1-4"
- [x] `bin/phish-merge --dry-run` — still runs all phases (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)