### PR TITLE
feat: nightly Borg backup for music library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Run ShellCheck on sync scripts
         run: |
           find sync -name "*.sh" -o -name "music-sync" -o -name "sync-*-to-plex" | xargs shellcheck -e SC1091
+          shellcheck bin/borg-backup bin/borg-backup-test
 
       - name: Run ShellCheck on test scripts
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This is a collection of music management tools for handling live show collection
 1. **Phish Collection Tools** (`bin/`): Python scripts for comparing, renaming, and merging Phish live show collections
 2. **Sync Scripts** (`sync/`): Bash scripts that use rsync to synchronize music collections between local storage, NAS backup, and Plex media server
 3. **ZSH Functions** (`zsh/functions/`): Audio conversion and metadata utilities
+4. **Borg Backup** (`bin/borg-backup`, `systemd/`): Bash script and systemd units for nightly incremental backup of the music library to a local NAS using Borg. Retention: 30 daily + 4 weekly + 12 monthly.
 
 ## Key Architecture Patterns
 
@@ -65,6 +66,27 @@ bin/phish-merge --phase 4 --dry-run
 ./sync/music-sync -n billy-strings   # Dry run preview
 ./sync/music-sync -y trey-anastasio  # Skip confirmation prompts
 ./sync/music-sync --help             # Show available artists and usage
+```
+
+### Borg Backup
+```bash
+# Run smoke test (uses temp dirs, safe anytime)
+bin/borg-backup-test
+
+# Check next scheduled run
+systemctl list-timers borg-music-backup
+
+# View last backup log
+journalctl -u borg-music-backup.service -n 200
+
+# List all archives
+borg list /data/media-nas/Backups/borg
+
+# One-time deployment (after cloning on a new machine)
+# Edit ExecStart in systemd/borg-music-backup.service to match your checkout path
+sudo cp systemd/borg-music-backup.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now borg-music-backup.timer
 ```
 
 ### Audio Functions (from zsh/functions/)
@@ -133,6 +155,9 @@ Required external tools:
   - `lib/` — Shared library functions (sync-lib.sh)
   - `music-sync` — Unified sync script for all artists
   - `*-excludes.txt` — Lists of studio albums/folders to exclude from live-only syncs
+- `systemd/` — Systemd unit files for scheduled backup
+  - `borg-music-backup.service` — Service that runs `bin/borg-backup`
+  - `borg-music-backup.timer` — Nightly trigger (2am, persistent)
 - `zsh/functions/` — Audio utility functions designed for zsh
 - `tests/` — Test suite
   - `*.bats` — Bats tests for sync scripts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,13 +143,16 @@ Required external tools:
 - `bats` — For running bats tests locally
 - `pyenv` — For managing Python version
 - `pytest` — For running Python tests locally
+- `borg` 1.2+ — Incremental backup for music library (`sudo apt-get install borgbackup`)
 
 ## File Structure
 
-- `bin/` — Phish collection Python tools
+- `bin/` — Phish collection Python tools and Borg backup scripts
   - `phish-rename` — Rename downloads to canonical LivePhish format
   - `phish-compare` — Compare existing collection vs torrent (read-only)
   - `phish-merge` — Merge torrent into existing collection
+  - `borg-backup` — Incremental Borg backup: init, create, prune, compact
+  - `borg-backup-test` — Smoke test helper using temp directories (safe to run anytime)
 - `sync/` — Music synchronization scripts and configurations
   - `config/` — Configuration files (global environment settings and per-artist configs)
   - `lib/` — Shared library functions (sync-lib.sh)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,42 @@ Modern, unified approach to synchronizing music collections:
 ./sync/music-sync -y trey-anastasio
 ```
 
+### Borg Backup (`bin/borg-backup`)
+
+Nightly incremental backup of the music library using [Borg](https://www.borgbackup.org/):
+
+- **Source:** `/data/media/Sorted/Unsorted/Music` (configured in `sync/config/global.conf`)
+- **Destination:** `/data/media-nas/Backups/borg` (configured in `sync/config/global.conf`)
+- **Retention:** 30 daily + 4 weekly + 12 monthly archives
+- **Compression:** lz4 (fast, near-zero CPU overhead)
+- **Encryption:** none (NAS is a trusted local destination)
+
+**One-time deployment:**
+```bash
+sudo cp systemd/borg-music-backup.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now borg-music-backup.timer
+```
+
+**Day-to-day operations:**
+```bash
+journalctl -u borg-music-backup.service    # full log of last run
+systemctl status borg-music-backup.timer   # next scheduled run
+systemctl list-timers borg-music-backup    # countdown to next run
+borg list /data/media-nas/Backups/borg     # list all archives
+borg info /data/media-nas/Backups/borg     # repo stats and disk usage
+```
+
+**Manual smoke test (uses temp directories, safe to run anytime):**
+```bash
+bin/borg-backup-test
+```
+
+**If the last run left a stale lock:**
+```bash
+borg break-lock /data/media-nas/Backups/borg
+```
+
 ### Audio Functions (`zsh/functions/`)
 
 Shell functions for audio processing:
@@ -303,6 +339,10 @@ tests/                        # Test suite
 zsh/functions/               # Audio processing utilities
 ├── flac2alac
 └── flacinfo
+
+systemd/
+├── borg-music-backup.service   # Systemd service unit
+└── borg-music-backup.timer     # Systemd timer unit (nightly at 2am)
 ```
 
 ## Dependencies
@@ -316,6 +356,7 @@ zsh/functions/               # Audio processing utilities
 - **python3** with `requests` and `beautifulsoup4` (for bin/ tools — see `requirements.txt`)
 - **bats** (for running bats tests locally)
 - **pytest** (for running Python tests locally)
+- **borg** 1.2+ (for music library backup — `sudo apt-get install borgbackup`)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ PARTIAL_DIR="/path/for/partial/transfers"
 RSYNC_BASE_OPTS="--archive --compress --verbose --human-readable --delete --progress --partial"
 DEFAULT_CONFIRM_PROMPTS=true
 DEFAULT_ENABLE_NAS_BACKUP=false
+BORG_SOURCE="/path/to/music/library"
+BORG_REPO="/path/to/borg/repository"
 ```
 
 ### Artist Configuration (`sync/config/<artist>.conf`)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Nightly incremental backup of the music library using [Borg](https://www.borgbac
 
 **One-time deployment:**
 ```bash
+# Edit ExecStart in systemd/borg-music-backup.service to match your checkout path
 sudo cp systemd/borg-music-backup.{service,timer} /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now borg-music-backup.timer
@@ -143,11 +144,11 @@ sudo systemctl enable --now borg-music-backup.timer
 
 **Day-to-day operations:**
 ```bash
-journalctl -u borg-music-backup.service    # full log of last run
-systemctl status borg-music-backup.timer   # next scheduled run
-systemctl list-timers borg-music-backup    # countdown to next run
-borg list /data/media-nas/Backups/borg     # list all archives
-borg info /data/media-nas/Backups/borg     # repo stats and disk usage
+journalctl -u borg-music-backup.service -n 200    # tail output from last run
+systemctl status borg-music-backup.timer          # timer active state
+systemctl list-timers borg-music-backup           # countdown to next run
+borg list /data/media-nas/Backups/borg            # list all archives
+borg info /data/media-nas/Backups/borg            # repo stats and disk usage
 ```
 
 **Manual smoke test (uses temp directories, safe to run anytime):**

--- a/bin/borg-backup
+++ b/bin/borg-backup
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../sync/config/global.conf"
+BORG="/usr/bin/borg"
+
+# Load configuration
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo "Error: Config file not found: $CONFIG_FILE" >&2
+    exit 1
+fi
+# shellcheck source=/dev/null
+source "$CONFIG_FILE"
+
+# Allow environment variable overrides (used by smoke test)
+BORG_SOURCE="${BORG_BACKUP_SOURCE:-$BORG_SOURCE}"
+BORG_REPO="${BORG_BACKUP_REPO:-$BORG_REPO}"
+
+# Validate prerequisites
+if [[ ! -x "$BORG" ]]; then
+    echo "Error: borg not found or not executable at $BORG" >&2
+    exit 1
+fi
+
+if [[ ! -d "$BORG_SOURCE" ]]; then
+    echo "Error: Source directory not found: $BORG_SOURCE" >&2
+    exit 1
+fi
+
+BORG_REPO_PARENT="$(dirname "$BORG_REPO")"
+if [[ ! -d "$BORG_REPO_PARENT" ]]; then
+    echo "Error: Repo parent directory not found: $BORG_REPO_PARENT" >&2
+    echo "Create it first: mkdir -p $BORG_REPO_PARENT" >&2
+    exit 1
+fi
+
+# Initialize repository on first run
+if [[ ! -d "$BORG_REPO" ]]; then
+    echo "=== Initializing Borg repository at $BORG_REPO ==="
+    "$BORG" init --encryption=none "$BORG_REPO"
+fi
+
+ARCHIVE_NAME="${HOSTNAME}-$(date +%Y-%m-%dT%H:%M:%S)"
+
+echo "=== Creating archive: $ARCHIVE_NAME ==="
+"$BORG" create \
+    --compression lz4 \
+    --stats \
+    --show-rc \
+    "${BORG_REPO}::${ARCHIVE_NAME}" \
+    "$BORG_SOURCE"
+
+echo ""
+echo "=== Pruning old archives ==="
+"$BORG" prune \
+    --list \
+    --show-rc \
+    --keep-daily=30 \
+    --keep-weekly=4 \
+    --keep-monthly=12 \
+    "$BORG_REPO"
+
+echo ""
+echo "=== Compacting repository ==="
+"$BORG" compact "$BORG_REPO"
+
+echo ""
+echo "=== Backup complete: ${BORG_REPO}::${ARCHIVE_NAME} ==="

--- a/bin/borg-backup
+++ b/bin/borg-backup
@@ -14,8 +14,17 @@ fi
 source "$CONFIG_FILE"
 
 # Allow environment variable overrides (used by smoke test)
-BORG_SOURCE="${BORG_BACKUP_SOURCE:-$BORG_SOURCE}"
-BORG_REPO="${BORG_BACKUP_REPO:-$BORG_REPO}"
+BORG_SOURCE="${BORG_BACKUP_SOURCE:-${BORG_SOURCE:-}}"
+BORG_REPO="${BORG_BACKUP_REPO:-${BORG_REPO:-}}"
+
+if [[ -z "$BORG_SOURCE" ]]; then
+    echo "Error: BORG_SOURCE is not set in $CONFIG_FILE and BORG_BACKUP_SOURCE is not set in the environment" >&2
+    exit 1
+fi
+if [[ -z "$BORG_REPO" ]]; then
+    echo "Error: BORG_REPO is not set in $CONFIG_FILE and BORG_BACKUP_REPO is not set in the environment" >&2
+    exit 1
+fi
 
 # Validate prerequisites
 if [[ ! -x "$BORG" ]]; then
@@ -56,6 +65,7 @@ echo "=== Pruning old archives ==="
 "$BORG" prune \
     --list \
     --show-rc \
+    --glob-archives "${HOSTNAME}-*" \
     --keep-daily=30 \
     --keep-weekly=4 \
     --keep-monthly=12 \

--- a/bin/borg-backup-test
+++ b/bin/borg-backup-test
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Manual smoke test for bin/borg-backup.
+# Overrides BORG_SOURCE and BORG_REPO to temp directories so the full
+# init -> create -> prune -> compact cycle runs without touching production data.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+FAKE_SOURCE="${TMPDIR_BASE}/music"
+FAKE_REPO_PARENT="${TMPDIR_BASE}/backups"
+
+mkdir -p "$FAKE_SOURCE"
+mkdir -p "$FAKE_REPO_PARENT"
+
+# Seed with a few dummy files so borg has something to back up
+echo "test track 1" > "${FAKE_SOURCE}/track1.flac"
+echo "test track 2" > "${FAKE_SOURCE}/track2.flac"
+mkdir -p "${FAKE_SOURCE}/Phish/2024-01-01"
+echo "setlist" > "${FAKE_SOURCE}/Phish/2024-01-01/notes.txt"
+
+echo "=== Borg Backup Smoke Test ==="
+echo "Source:  $FAKE_SOURCE"
+echo "Repo:    ${FAKE_REPO_PARENT}/borg"
+echo ""
+
+BORG_BACKUP_SOURCE="$FAKE_SOURCE" \
+BORG_BACKUP_REPO="${FAKE_REPO_PARENT}/borg" \
+    "${SCRIPT_DIR}/borg-backup"
+
+echo ""
+echo "=== Archives in test repo ==="
+/usr/bin/borg list "${FAKE_REPO_PARENT}/borg"
+
+echo ""
+echo "=== Smoke test PASSED ==="

--- a/bin/borg-backup-test
+++ b/bin/borg-backup-test
@@ -26,6 +26,11 @@ echo "Source:  $FAKE_SOURCE"
 echo "Repo:    ${FAKE_REPO_PARENT}/borg"
 echo ""
 
+if [[ ! -x "${SCRIPT_DIR}/borg-backup" ]]; then
+    echo "Error: ${SCRIPT_DIR}/borg-backup not found — run Task 3 first" >&2
+    exit 1
+fi
+
 BORG_BACKUP_SOURCE="$FAKE_SOURCE" \
 BORG_BACKUP_REPO="${FAKE_REPO_PARENT}/borg" \
     "${SCRIPT_DIR}/borg-backup"

--- a/sync/config/global.conf
+++ b/sync/config/global.conf
@@ -18,3 +18,7 @@ RSYNC_BASE_OPTS="--archive --compress --verbose --human-readable --delete --prog
 # Default behavior
 DEFAULT_CONFIRM_PROMPTS=true
 DEFAULT_ENABLE_NAS_BACKUP=false
+
+# Borg backup configuration
+BORG_SOURCE="/data/media/Sorted/Unsorted/Music"
+BORG_REPO="/data/media-nas/Backups/borg"

--- a/systemd/borg-music-backup.service
+++ b/systemd/borg-music-backup.service
@@ -4,9 +4,11 @@ After=local-fs.target
 
 [Service]
 Type=oneshot
+# Update ExecStart to the actual checkout path on the deployment machine
 ExecStart=/home/ian/src/ianchesal/music-management/bin/borg-backup
 Nice=19
 IOSchedulingClass=idle
+TimeoutStartSec=0
 ProtectSystem=strict
 ReadOnlyPaths=/data/media/Sorted/Unsorted/Music
 ReadWritePaths=/data/media-nas/Backups/borg

--- a/systemd/borg-music-backup.service
+++ b/systemd/borg-music-backup.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Borg Music Library Backup
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/ian/src/ianchesal/music-management/bin/borg-backup
+Nice=19
+IOSchedulingClass=idle
+ProtectSystem=strict
+ReadOnlyPaths=/data/media/Sorted/Unsorted/Music
+ReadWritePaths=/data/media-nas/Backups/borg
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/borg-music-backup.timer
+++ b/systemd/borg-music-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Nightly Borg Music Library Backup Timer
+
+[Timer]
+OnCalendar=*-*-* 02:00:00
+Persistent=true
+RandomizedDelaySec=300
+Unit=borg-music-backup.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- Adds `bin/borg-backup`: a bash script that auto-inits, creates, prunes, and compacts a Borg repository nightly. Retention policy: 30 daily + 4 weekly + 12 monthly archives.
- Adds `systemd/borg-music-backup.service` and `.timer`: oneshot service with `Nice=19`, `IOSchedulingClass=idle`, `ProtectSystem=strict`, `TimeoutStartSec=0`; timer fires at 2am with `Persistent=true` so missed runs catch up on next boot.
- Adds `bin/borg-backup-test`: manual smoke test helper that overrides source/repo paths to temp directories — safe to run anytime.
- Source (`BORG_SOURCE`) and repo (`BORG_REPO`) paths are configured in `sync/config/global.conf` alongside the existing sync variables.

## Hardening beyond the original spec

- Empty-variable guards (`${BORG_SOURCE:-}`) with actionable error messages defend against a `global.conf` that loads but has the variables missing or commented out.
- `borg prune` is scoped to `--glob-archives "${HOSTNAME}-*"` to prevent cross-host archive deletion if the repo is ever shared.
- `TimeoutStartSec=0` prevents systemd's default 90s timeout from killing a long first-run backup.

## Test Plan

- [x] Run `bin/borg-backup-test` — should complete init → create → prune → compact and print "Smoke test PASSED"
- [x] Deploy units: edit `ExecStart` in `systemd/borg-music-backup.service` to match checkout path, then `sudo cp systemd/borg-music-backup.{service,timer} /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now borg-music-backup.timer`
- [x] Verify timer is scheduled: `systemctl list-timers borg-music-backup`
- [ ] After first nightly run: `borg list /data/media-nas/Backups/borg` should show one archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)