### PR TITLE
fix: suppress borg unencrypted repo prompt for non-interactive service runs

### DIFF
--- a/bin/borg-backup
+++ b/bin/borg-backup
@@ -44,6 +44,9 @@ if [[ ! -d "$BORG_REPO_PARENT" ]]; then
     exit 1
 fi
 
+# Suppress borg's interactive prompt when accessing an unencrypted repo for the first time
+export BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=yes
+
 # Initialize repository on first run
 if [[ ! -d "$BORG_REPO" ]]; then
     echo "=== Initializing Borg repository at $BORG_REPO ==="


### PR DESCRIPTION
## Summary

- Suppresses the interactive prompt Borg shows when operating on an unencrypted repository, which was causing the systemd service to hang waiting for user input

## Test plan

- [x] Verify `bin/borg-backup` runs without hanging when triggered via systemd service
- [x] Confirm `borg list` and `borg create` commands complete successfully in non-interactive mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)