### PR TITLE
phish-retag: one-off round-trip exception for Dick's Sporting Goods Park

### DIFF
--- a/bin/phish-retag
+++ b/bin/phish-retag
@@ -137,10 +137,21 @@ def split_venue_city(location_dots: str, album_tag: str | None) -> str | None:
     return None
 
 
+# One-off: livephish's official name for this venue carries an apostrophe
+# ("Dick's Sporting Goods Park") that this collection's directory names
+# strip ("Dicks.Sporting.Goods.Park..."). Comparison-only — the apostrophe
+# is kept in the tag text actually written, this just isn't a real
+# location mismatch worth landing in the unresolved bucket over.
+ROUND_TRIP_QUIRKS = {"Dick's": "Dicks"}
+
+
 def round_trip_ok(resolved: str, location_dots: str) -> bool:
     """Hard invariant: re-dotting the resolved location must reproduce the
     directory's location string — that is exactly how dir names were built."""
-    return dot_normalize(location_to_dots(resolved)) == dot_normalize(location_dots)
+    comparable = resolved
+    for quirky, plain in ROUND_TRIP_QUIRKS.items():
+        comparable = comparable.replace(quirky, plain)
+    return dot_normalize(location_to_dots(comparable)) == dot_normalize(location_dots)
 
 
 # ── Cache ──────────────────────────────────────────────────────────────────────

--- a/tests/test_phish_retag.py
+++ b/tests/test_phish_retag.py
@@ -145,6 +145,21 @@ class TestRoundTripOk:
             "Hampton Coliseum, Hampton, VA", "Madison.Square.Garden.New.York.NY"
         ) is False
 
+    def test_dicks_apostrophe_quirk_round_trips(self):
+        # livephish's official name carries an apostrophe; this collection's
+        # directory names strip it. One-off exception, not a real mismatch.
+        assert pt.round_trip_ok(
+            "Dick's Sporting Goods Park, Commerce City, CO",
+            "Dicks.Sporting.Goods.Park.Commerce.City.CO",
+        ) is True
+
+    def test_other_apostrophes_are_not_silently_stripped(self):
+        # The quirk list is a literal one-off, not a general apostrophe
+        # stripper — an unrelated apostrophe mismatch should still fail.
+        assert pt.round_trip_ok(
+            "Bill's Bar, Boston, MA", "Bills.Bar.Boston.MA"
+        ) is False
+
 
 class TestCache:
     def test_default_path_honors_xdg_cache_home(self, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- `phish-retag`'s round-trip invariant compares `location_to_dots(resolved)` against the directory's location string. livephish's official name for this venue, "Dick's Sporting Goods Park," carries an apostrophe that this collection's directory names strip (`Dicks.Sporting.Goods.Park...`), so the three 2011-09-02/03/04 Commerce City, CO shows were landing in the `unresolved` bucket even though livephish correctly resolves them.
- Adds a narrowly-scoped, literal exception (`ROUND_TRIP_QUIRKS = {"Dick's": "Dicks"}`) applied only inside the round-trip comparison — the tag text actually written still keeps the apostrophe. Not a general apostrophe stripper: added a test confirming an unrelated apostrophe mismatch still correctly fails.

## Test plan
- [x] `pytest tests/` — 162/162 passing
- [x] `bats tests/*.bats` — 28/28 passing
- [x] Verified against the real collection: `round_trip_ok("Dick's Sporting Goods Park, Commerce City, CO", "Dicks.Sporting.Goods.Park.Commerce.City.CO")` now returns `True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)