### PR TITLE
phish-retag: normalize date tag to show date

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Three Python tools designed to work together as a pipeline when integrating a Li
 - **`phish-rename`** — Queries livephish.com to rename show directories from any date-based format to `Phish-YYYY-MM-DD.Dot.Separated.Location.[LivePhishID]`. Requires `requests` and `beautifulsoup4`.
 - **`phish-compare`** — Read-only diagnostic: shows matched/unmatched shows, studio album cross-references, and undated items in both the existing collection and torrent.
 - **`phish-merge`** — Performs the actual merge in up to four phases: (1) rsync backup to NAS, (2) copy torrent-only shows, (3) replace matched shows with canonical torrent copies, (4) rename existing-only shows to torrent naming style. Supports `--dry-run` and `--phase N`.
-- **`phish-retag`** — Normalizes the album tag on every audio file in canonical show directories to `YYYY/MM/DD Venue, City, ST`, derived from the directory name. Venue/city boundaries resolve from existing tags when possible, falling back to livephish.com (jittered requests, results cached in `$XDG_CACHE_HOME/phish-retag.json`). Clean multi-set directories — distinct album tags differing only by a set marker (`I`-`V`) right after the date, with otherwise-matching venue text — get the marker converted to a `discnumber` tag and the album collapsed to the uniform format. Messier multi-set directories (contamination, missing markers, disagreeing venue text) are skipped with a warning. Only the album and discnumber tags are touched. Requires `mutagen`.
+- **`phish-retag`** — Normalizes the album tag on every audio file in canonical show directories to `YYYY/MM/DD Venue, City, ST`, derived from the directory name, and normalizes the date tag to the show's date (`YYYY-MM-DD`). Venue/city boundaries resolve from existing tags when possible, falling back to livephish.com (jittered requests, results cached in `$XDG_CACHE_HOME/phish-retag.json`). Clean multi-set directories — distinct album tags differing only by a set marker (`I`-`V`) right after the date, with otherwise-matching venue text — get the marker converted to a `discnumber` tag and the album collapsed to the uniform format. Messier multi-set directories (contamination, missing markers, disagreeing venue text) are skipped with a warning. Only the album, discnumber, and date tags are touched. Requires `mutagen`.
 
 All four tools share the same date-extraction logic, and the collection tools share these default paths:
 - `DEFAULT_EXISTING = /data/media/Sorted/Unsorted/Music/Phish`
@@ -158,7 +158,7 @@ Required external tools:
   - `phish-rename` — Rename downloads to canonical LivePhish format
   - `phish-compare` — Compare existing collection vs torrent (read-only)
   - `phish-merge` — Merge torrent into existing collection
-  - `phish-retag` — Normalize album tags to YYYY/MM/DD Venue, City, ST
+  - `phish-retag` — Normalize album tags to YYYY/MM/DD Venue, City, ST and date tags to YYYY-MM-DD
   - `borg-backup` — Incremental Borg backup: init, create, prune, compact
   - `borg-backup-test` — Smoke test helper using temp directories (safe to run anytime)
 - `sync/` — Music synchronization scripts and configurations

--- a/bin/phish-retag
+++ b/bin/phish-retag
@@ -7,7 +7,9 @@ Scans PATH for canonical show directories
 album tag on every audio file to:
   YYYY/MM/DD Venue, City, ST
 
-Only the album and discnumber tags are touched. A "clean" multi-set show —
+The date tag is also normalized to the show's date (YYYY-MM-DD).
+
+Only the album, discnumber, and date tags are touched. A "clean" multi-set show —
 one whose distinct album tags differ only by a set marker (I-V) right after
 the date, with matching venue/city text otherwise — has its set marker
 converted to a discnumber tag and its album collapsed to the same uniform
@@ -389,6 +391,28 @@ def write_discnumber(path: Path, discnumber: str) -> bool:
     return True
 
 
+def read_date(path: Path):
+    """Date tag of an audio file: None if unreadable, "" if untagged."""
+    audio = _open_audio(path)
+    if audio is None:
+        return None
+    if audio.tags is None:
+        return ""
+    values = audio.get("date")
+    return values[0] if values else ""
+
+
+def write_date(path: Path, date: str) -> bool:
+    audio = _open_audio(path)
+    if audio is None:
+        return False
+    if audio.tags is None:
+        audio.add_tags()
+    audio["date"] = date
+    audio.save()
+    return True
+
+
 # ── Main logic ─────────────────────────────────────────────────────────────────
 
 def main_logic(path: Path, execute: bool, cache_path: Path) -> dict:
@@ -451,11 +475,14 @@ def main_logic(path: Path, execute: bool, cache_path: Path) -> dict:
                 continue
 
             target = target_album(date, resolved)
-            # Defensive: in practice this is never True here — a directory where every
-            # file's tag has already collapsed to the uniform target album would have
-            # only one distinct tag, routing through the single-tag branch above instead.
+            dates = {f: read_date(f) for f in files if f in albums}
+            # Defensive: in practice all_correct is rarely True here — a directory
+            # where every file's tag had already collapsed to the uniform target
+            # album (and date) would have only one distinct tag, routing through
+            # the single-tag branch above instead.
             all_correct = all(
                 albums[f] == target and read_discnumber(f) == str(clean[albums[f]])
+                and dates.get(f) == date
                 for f in files if f in albums
             )
             if all_correct:
@@ -468,12 +495,15 @@ def main_logic(path: Path, execute: bool, cache_path: Path) -> dict:
             print(f"  {prefix}{entry.name}")
             for tag in sorted(clean, key=clean.get):
                 print(f"      Disc {clean[tag]}: {tag} → {green(target)}")
+            if any(dates.get(f) != date for f in files if f in albums):
+                print(f"      date → {green(date)}")
             for f in files:
                 if f not in albums:
                     continue
                 tag = albums[f]
                 disc_str = str(clean[tag])
-                if albums.get(f) == target and read_discnumber(f) == disc_str:
+                date_ok = dates.get(f) == date
+                if albums.get(f) == target and read_discnumber(f) == disc_str and date_ok:
                     continue
                 if execute:
                     if not write_album(f, target):
@@ -481,6 +511,9 @@ def main_logic(path: Path, execute: bool, cache_path: Path) -> dict:
                         continue
                     if not write_discnumber(f, disc_str):
                         print(f"  {yellow('WARN')} could not write discnumber: {f}", file=sys.stderr)
+                        continue
+                    if not date_ok and not write_date(f, date):
+                        print(f"  {yellow('WARN')} could not write date tag: {f}", file=sys.stderr)
                         continue
                 files_updated += 1
             continue
@@ -495,22 +528,34 @@ def main_logic(path: Path, execute: bool, cache_path: Path) -> dict:
             continue
 
         target = target_album(date, resolved)
-        if current == target:
+        dates = {f: read_date(f) for f in files if f in albums}
+        album_ok = current == target
+        dates_ok = all(d == date for d in dates.values())
+        if album_ok and dates_ok:
             counts["already"] += 1
             continue
 
         counts["updated"] += 1
         prefix = "[DRY RUN] " if not execute else ""
         print(f"  {prefix}{entry.name}")
-        print(f"      {current or '(no album tag)'} → {green(target)}")
+        if not album_ok:
+            print(f"      {current or '(no album tag)'} → {green(target)}")
+        if not dates_ok:
+            wrong = sorted({d or "(no date tag)" for d in dates.values() if d != date})
+            print(f"      {', '.join(wrong)} → {green(date)}")
         for f in files:
             if f not in albums:
                 continue
-            if albums.get(f) == target:
+            needs_album = albums.get(f) != target
+            needs_date = dates.get(f) != date
+            if not needs_album and not needs_date:
                 continue
             if execute:
-                if not write_album(f, target):
+                if needs_album and not write_album(f, target):
                     print(f"  {yellow('WARN')} could not write tag: {f}", file=sys.stderr)
+                    continue
+                if needs_date and not write_date(f, date):
+                    print(f"  {yellow('WARN')} could not write date tag: {f}", file=sys.stderr)
                     continue
             files_updated += 1
 

--- a/tests/test_phish_retag.py
+++ b/tests/test_phish_retag.py
@@ -445,15 +445,18 @@ def audio_fixtures(tmp_path_factory):
     return paths
 
 
-def make_show_file(fixtures, dest_dir, name, album=None):
+def make_show_file(fixtures, dest_dir, name, album=None, date=None):
     dest = Path(dest_dir) / name
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(fixtures[name.rsplit(".", 1)[1]], dest)
-    if album is not None:
+    if album is not None or date is not None:
         audio = mutagen.File(str(dest), easy=True)
         if audio.tags is None:
             audio.add_tags()
-        audio["album"] = album
+        if album is not None:
+            audio["album"] = album
+        if date is not None:
+            audio["date"] = date
         audio.save()
     return dest
 
@@ -514,6 +517,30 @@ class TestTagIO:
         assert pt.read_discnumber(junk) is None
         assert pt.write_discnumber(junk, "1") is False
 
+    @pytest.mark.parametrize("ext", ["flac", "m4a", "mp3"])
+    def test_write_then_read_date(self, audio_fixtures, tmp_path, ext):
+        f = make_show_file(audio_fixtures, tmp_path, f"track.{ext}")
+        assert pt.write_date(f, "1996-12-06") is True
+        assert pt.read_date(f) == "1996-12-06"
+
+    @pytest.mark.parametrize("ext", ["flac", "m4a", "mp3"])
+    def test_missing_date_reads_empty_string(self, audio_fixtures, tmp_path, ext):
+        f = make_show_file(audio_fixtures, tmp_path, f"track.{ext}")
+        assert pt.read_date(f) == ""
+
+    def test_date_write_preserves_album(self, audio_fixtures, tmp_path):
+        f = make_show_file(audio_fixtures, tmp_path, "track.flac",
+                           album="1994/05/07 Dallas, TX")
+        pt.write_date(f, "1994-05-07")
+        assert pt.read_album(f) == "1994/05/07 Dallas, TX"
+        assert pt.read_date(f) == "1994-05-07"
+
+    def test_unreadable_file_date_returns_none(self, tmp_path):
+        junk = tmp_path / "junk.flac"
+        junk.write_bytes(b"not audio at all")
+        assert pt.read_date(junk) is None
+        assert pt.write_date(junk, "1996-12-06") is False
+
 
 class TestCollectAudio:
     def test_finds_audio_recursively_and_sorted(self, audio_fixtures, tmp_path):
@@ -542,7 +569,8 @@ def build_collection(audio_fixtures, root):
     # Already correct
     d2 = root / "Phish-2026-07-12.Ruoff.Music.Center.Noblesville.IN.[2754]"
     make_show_file(audio_fixtures, d2, "t1.flac",
-                   album="2026/07/12 Ruoff Music Center, Noblesville, IN")
+                   album="2026/07/12 Ruoff Music Center, Noblesville, IN",
+                   date="2026-07-12")
     # Clean multi-set: two distinct tags differing only by set marker
     d3 = root / "Phish-1994-12-29.Providence.Civic.Center.Providence.RI.[498]"
     make_show_file(audio_fixtures, d3, "s1.flac", album="1994/12/29 I Providence, RI")
@@ -698,6 +726,65 @@ class TestMainLogic:
         counts = self._run(root, tmp_path / "c.json", execute=False)
         assert counts == {"updated": 0, "already": 0, "multiset_clean": 0,
                           "multiset_anomaly": 0, "unresolved": 0, "skipped": 1}
+
+
+class TestDateNormalization:
+    def _run(self, root, cache_file, execute):
+        with patch.object(pt, "livephish_location", return_value=None):
+            return pt.main_logic(root, execute=execute, cache_path=cache_file)
+
+    def test_wrong_date_triggers_update_even_when_album_correct(self, audio_fixtures, tmp_path):
+        root = tmp_path / "col"
+        d = root / "Phish-2026-07-12.Ruoff.Music.Center.Noblesville.IN.[2754]"
+        make_show_file(audio_fixtures, d, "t1.flac",
+                       album="2026/07/12 Ruoff Music Center, Noblesville, IN",
+                       date="2026-07-11")
+        counts = self._run(root, tmp_path / "c.json", execute=True)
+        assert counts["updated"] == 1
+        assert counts["already"] == 0
+        assert pt.read_album(d / "t1.flac") == "2026/07/12 Ruoff Music Center, Noblesville, IN"
+        assert pt.read_date(d / "t1.flac") == "2026-07-12"
+
+    def test_missing_date_is_set_alongside_album_fix(self, audio_fixtures, tmp_path):
+        root = tmp_path / "col"
+        d1, d2, *_ = build_collection(audio_fixtures, root)
+        self._run(root, tmp_path / "c.json", execute=True)
+        assert pt.read_date(d1 / "t1.flac") == "2026-07-21"
+        assert pt.read_date(d1 / "t2.flac") == "2026-07-21"
+
+    def test_clean_multiset_gets_date_set_on_every_file(self, audio_fixtures, tmp_path):
+        root = tmp_path / "col"
+        _, _, d3, *_ = build_collection(audio_fixtures, root)
+        self._run(root, tmp_path / "c.json", execute=True)
+        assert pt.read_date(d3 / "s1.flac") == "1994-12-29"
+        assert pt.read_date(d3 / "s2.flac") == "1994-12-29"
+
+    def test_unresolved_and_anomaly_dirs_leave_date_untouched(self, audio_fixtures, tmp_path):
+        root = tmp_path / "col"
+        _, _, _, d4, _, d6 = build_collection(audio_fixtures, root)
+        self._run(root, tmp_path / "c.json", execute=True)
+        assert pt.read_date(d4 / "t1.flac") == ""
+        assert pt.read_date(d6 / "s1.flac") == ""
+
+    def test_dry_run_does_not_write_date(self, audio_fixtures, tmp_path):
+        root = tmp_path / "col"
+        d = root / "Phish-2026-07-12.Ruoff.Music.Center.Noblesville.IN.[2754]"
+        make_show_file(audio_fixtures, d, "t1.flac",
+                       album="2026/07/12 Ruoff Music Center, Noblesville, IN",
+                       date="2026-07-11")
+        counts = self._run(root, tmp_path / "c.json", execute=False)
+        assert counts["updated"] == 1
+        assert pt.read_date(d / "t1.flac") == "2026-07-11"
+
+    def test_dry_run_prints_date_diff(self, audio_fixtures, tmp_path, capsys):
+        root = tmp_path / "col"
+        d = root / "Phish-2026-07-12.Ruoff.Music.Center.Noblesville.IN.[2754]"
+        make_show_file(audio_fixtures, d, "t1.flac",
+                       album="2026/07/12 Ruoff Music Center, Noblesville, IN",
+                       date="2026-07-11")
+        self._run(root, tmp_path / "c.json", execute=False)
+        out = capsys.readouterr().out
+        assert "2026-07-11 → 2026-07-12" in out
 
 
 class TestParseArgs:


### PR DESCRIPTION
## Summary
- `phish-retag` now normalizes the `date` tag (`YYYY-MM-DD`, the show's date) alongside the existing album/discnumber normalization — Plex/Plexamp read `date` as the release date, so it should match the show rather than whatever LivePhish shipped.
- Applies on the same paths as album correction: single-tag shows and clean multi-set shows. Unresolved and messy multi-set directories are left untouched, same as before.
- Dry-run output now shows a date diff line when the date tag needs correcting.

## Test plan
- [x] `pytest tests/test_phish_retag.py -q` (120 passed)
- [x] `cd tests && bats *.bats && cd .. && pytest tests/` (28 bats + 213 pytest, all passing)