### PR TITLE
feat: match YYYY.MM.DD directories in phish-rename

### DIFF
--- a/bin/phish-rename
+++ b/bin/phish-rename
@@ -2,7 +2,7 @@
 """
 phish-rename — Rename new Phish live show downloads to canonical LivePhish format.
 
-Scans PATH for directories matching YYYY-MM-DD or YYYY_MM_DD naming patterns,
+Scans PATH for directories matching YYYY-MM-DD, YYYY_MM_DD, or YYYY.MM.DD naming patterns,
 looks up each show on livephish.com, and renames to:
   Phish-YYYY-MM-DD.Dot.Separated.Location.[LivePhishID]
 
@@ -65,7 +65,7 @@ HEADERS = {
 # ── Core functions ─────────────────────────────────────────────────────────────
 
 def date_from_dirname(dirname: str):
-    m = re.match(r'^(\d{4})[-_](\d{1,2})[-_](\d{1,2})\b', dirname)
+    m = re.match(r'^(\d{4})[-_.](\d{1,2})[-_.](\d{1,2})\b', dirname)
     if m:
         y, mo, d = m.group(1), int(m.group(2)), int(m.group(3))
         return f"{y}-{mo:02d}-{d:02d}"

--- a/tests/test_phish_rename.py
+++ b/tests/test_phish_rename.py
@@ -46,6 +46,9 @@ class TestDateFromDirname:
     def test_yyyy_underscore_mm_dd(self):
         assert pr.date_from_dirname("2024_07_20 Xfinity Center Mansfield MA") == "2024-07-20"
 
+    def test_yyyy_dot_mm_dd(self):
+        assert pr.date_from_dirname("2024.07.20 Xfinity Center Mansfield MA") == "2024-07-20"
+
     def test_single_digit_month(self):
         assert pr.date_from_dirname("1994_6_19 Somewhere") == "1994-06-19"
 


### PR DESCRIPTION
## Summary
- `phish-rename` now recognizes dot-separated `YYYY.MM.DD` directory names in addition to `YYYY-MM-DD` and `YYYY_MM_DD`

## Test plan
- [x] `pytest tests/test_phish_rename.py -q` (39 passed, including new `test_yyyy_dot_mm_dd`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)